### PR TITLE
Remove Command of Downloading Virtual Machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,9 @@ Install the virtualisation suite:
 - VirtualBox
 - Vagrant
 
-Download image and launch virtual machine:
+Launch virtual machine:
 
 ```
-vagrant box add ubuntu/trusty64
 vagrant up
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Then, in the root project directory, run this to install all JavaScript packages
 npm install
 ```
 
-### Virtual Environemnt for Development
+### Virtual Environment for Development
 Install the virtualisation suite:
 
 - VirtualBox


### PR DESCRIPTION
No need to run "vagrant box add ubuntu/trusty64" for download the image.

"vagrant up" does all the things for us. When "vagrant up", if image of "ubuntu/trusty64" doesn't exists, it will be download. If it already exists, downloading will be skipped, which saves a lot of time.